### PR TITLE
Cope with fonts that have a different prefix

### DIFF
--- a/crawl_result_font.go
+++ b/crawl_result_font.go
@@ -38,7 +38,6 @@ func (c *crawlResultFonts) parse(propVal *[]byte) error {
 		var crFont crawlResultFont
 
 		prefix, fontIndex, err := splitFont(strings.TrimSpace(prop.key))
-		fmt.Printf("splitFont %s: %s %d\n", prop.key, prefix, fontIndex)
 		if err != nil {
 			return err
 		}

--- a/crawl_result_font.go
+++ b/crawl_result_font.go
@@ -5,9 +5,26 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 type crawlResultFonts []crawlResultFont
+
+// Split a font string like '/F1' or '/TT2' into the prefix and index
+func splitFont(s string) (string, int, error) {
+	prefix := ""
+	for i, r := range s {
+		if unicode.IsDigit(r) {
+			val, err := strconv.Atoi(s[i:])
+			if err != nil {
+				return "", 0, err
+			}
+			return prefix, val, nil
+		}
+		prefix += string(r)
+	}
+	return "", 0, fmt.Errorf("No font index")
+}
 
 func (c *crawlResultFonts) parse(propVal *[]byte) error {
 	var props PDFObjPropertiesData
@@ -16,9 +33,12 @@ func (c *crawlResultFonts) parse(propVal *[]byte) error {
 		return err
 	}
 
+
 	for _, prop := range props {
 		var crFont crawlResultFont
-		fontIndex, err := strconv.Atoi(strings.TrimSpace(strings.Replace(prop.key, "F", "", -1)))
+
+		prefix, fontIndex, err := splitFont(strings.TrimSpace(prop.key))
+		fmt.Printf("splitFont %s: %s %d\n", prop.key, prefix, fontIndex)
 		if err != nil {
 			return err
 		}
@@ -26,6 +46,7 @@ func (c *crawlResultFonts) parse(propVal *[]byte) error {
 		if err != nil {
 			return err
 		}
+		crFont.prefix = prefix
 		crFont.fontIndex = fontIndex
 		crFont.fontObjID = objID
 		*c = append(*c, crFont)
@@ -36,7 +57,7 @@ func (c *crawlResultFonts) parse(propVal *[]byte) error {
 func (c *crawlResultFonts) String() string {
 	var buff bytes.Buffer
 	for _, f := range *c {
-		buff.WriteString(fmt.Sprintf("/F%d %d 0 R\n", f.fontIndex, f.fontObjID))
+		buff.WriteString(fmt.Sprintf("/%s%d %d 0 R\n", f.prefix, f.fontIndex, f.fontObjID))
 	}
 	return buff.String()
 }
@@ -45,6 +66,7 @@ func (c *crawlResultFonts) append(fontIndex int, fontObjID int) {
 	var crFont crawlResultFont
 	crFont.fontIndex = fontIndex
 	crFont.fontObjID = fontObjID
+	crFont.prefix = "F"
 	*c = append(*c, crFont)
 }
 
@@ -61,4 +83,5 @@ func (c *crawlResultFonts) maxFontIndex() int {
 type crawlResultFont struct {
 	fontIndex int
 	fontObjID int
+	prefix string
 }

--- a/pdf_obj_data.go
+++ b/pdf_obj_data.go
@@ -30,7 +30,8 @@ func (p *PDFObjData) parse(raw *[]byte, stratoffset int) error {
 	}
 
 	startObjOffsetAfter := startObjIndex[0][1]
-	startObjLine := tmp[0:startObjOffsetAfter]
+	startObjOffset := startObjIndex[0][0]
+	startObjLine := tmp[startObjOffset:startObjOffsetAfter]
 	data := tmp[startObjOffsetAfter:]
 	objID, err := objIDFromStartObjLine(string(startObjLine))
 	if err != nil {


### PR DESCRIPTION
Some PDFs have a prefix of '/TT' instead of '/F' on fonts