### PR TITLE
Cope with more whitespace in objid records

### DIFF
--- a/pdf_data.go
+++ b/pdf_data.go
@@ -614,7 +614,7 @@ func findMaxFontIndex(cw *crawl, p *PDFData) (int, error) {
 }
 
 func objIDFromStartObjLine(line string) (int, error) {
-	tokens := strings.Split(line, " ")
+	tokens := strings.Fields(line)
 	if len(tokens) < 3 {
 		return 0, errors.New("bad start obj")
 	}

--- a/regex.go
+++ b/regex.go
@@ -4,7 +4,7 @@ import "regexp"
 
 var regexpXref = regexp.MustCompile("xref")
 var regexpXrefLine = regexp.MustCompile("[0-9]{10}[\\t ]+[0-9]{5}[\\t ][f,n]")
-var regexpStartObj = regexp.MustCompile("[0-9]+[\\t ]0[\\t ]obj")
+var regexpStartObj = regexp.MustCompile("[0-9]+[\\n\\r\\t ]0[\\n\\r\\t ]obj")
 var regexpEndObj = regexp.MustCompile("endobj")
 var regexpTrailer = regexp.MustCompile("trailer")
 var regexpStartxref = regexp.MustCompile("startxref")


### PR DESCRIPTION
Some PDFs specify objects with new lines rather than spaces, ie:
1
0
obj
<<
/Type
/Pages
/Kids
[
6
0
R
]
/Count
1
>>
endobj